### PR TITLE
interaction time variable & typo fixes

### DIFF
--- a/notebooks/Self-Driving Cars [Part 1- The ALV].ipynb
+++ b/notebooks/Self-Driving Cars [Part 1- The ALV].ipynb
@@ -610,7 +610,7 @@
     }
    ],
    "source": [
-    "interact(apply_alv_vision, t = (40, 130), thresh = (-64, 64))"
+    "interact(apply_alv_vision, t = (0, 10), thresh = (-64, 64))"
    ]
   },
   {

--- a/notebooks/Self-Driving Cars [Part 2 - ALVINN].ipynb
+++ b/notebooks/Self-Driving Cars [Part 2 - ALVINN].ipynb
@@ -672,7 +672,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Our network has learned to intrepret driving images based ONLY on steering angle! \n",
+    "- Our network has learned to interpret driving images based ONLY on steering angle! \n",
     "- For this data (track data with only left turns), our network has learned a set of lane marker detectors!\n"
    ]
   },
@@ -688,7 +688,7 @@
    "metadata": {},
    "source": [
     "- For a number of years from the late 1980s to the early 1990s, ALVINN was the most successfull vision algorithm for autonomous driving at CMU, and possibly on the planet.\n",
-    "- Faster computers enabled faster driving, and more sophisiticed training and data augmentation procedures allowed ALVINN to learn quickly and effectively across many environments."
+    "- Faster computers enabled faster driving, and more sophisticated training and data augmentation procedures allowed ALVINN to learn quickly and effectively across many environments."
    ]
   },
   {
@@ -703,7 +703,7 @@
    "metadata": {},
    "source": [
     "- And quite recently, Nvidia implemented Pomerleau's idea using **Deep Neural Networks**\n",
-    "- Great writeup in thier publication [End to end learning for self-driving cars](https://images.nvidia.com/content/tegra/automotive/images/2016/solutions/pdf/end-to-end-dl-using-px.pdf)\n",
+    "- Great writeup in their publication [End to end learning for self-driving cars](https://images.nvidia.com/content/tegra/automotive/images/2016/solutions/pdf/end-to-end-dl-using-px.pdf)\n",
     "- Pomerleau orinally trained on ~5 minutes of driving, Nvidia trained on 3000 hours\n",
     "    - That's 36,000 times the amount of data - **5 orders of magnitude** increase in dataset size in 30 years. \n"
    ]

--- a/notebooks/Self-Driving Cars [Part 2 - ALVINN].ipynb
+++ b/notebooks/Self-Driving Cars [Part 2 - ALVINN].ipynb
@@ -110,8 +110,8 @@
     "collapsed": true
    },
    "source": [
-    "- Is it possible to train a nueral network to learn **all the math** to steer a car?\n",
-    "    - [FUN FACT] when I began working in autonomous driving in June 2016 I had exactly this conversation with a long-time friend and coworker, and I argued this this might not even be possible. Let's see if I was right..."
+    "- Is it possible to train a neural network to learn **all the math** to steer a car?\n",
+    "    - [FUN FACT] when I began working in autonomous driving in June 2016 I had exactly this conversation with a long-time friend and coworker, and I argued that this might not even be possible. Let's see if I was right..."
    ]
   },
   {
@@ -169,9 +169,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Here's the nueral network architecture used by Dean Pomerleau\n",
+    "- Here's the neural network architecture used by Dean Pomerleau\n",
     "- Pomerleau (at least initially) just used the blue image channel, and downsampled his images to just (30x32) pixels.\n",
-    "- The output of ALVINN is setup cleverly - steering angles are grouped into 30 discrete bins, and training data is setups as a guasian distribution around the the bin corresnponding to the current steering angle - this makes the problem more linear - small changes in input images correspond to small changes in output values."
+    "- The output of ALVINN is setup cleverly - steering angles are grouped into 30 discrete bins, and training data is setups as a guasian distribution around the the bin corresponding to the current steering angle - this makes the problem more linear - small changes in input images correspond to small changes in output values."
    ]
   },
   {


### PR DESCRIPTION
notebook 1) 0 to 10 works as a time variable. Whereas (40, 130) shows "OSError: MoviePy error" on my OS X system. And the video is only 10 seconds long.

notebook 2) correction of some typos.
